### PR TITLE
Use tar library instead of deprecated tar.gz

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-var targz = require('tar.gz');
+var tar = require('tar');
 var download = require('./');
 
 download({version: process.argv[2] || process.env.npm_package_libui})
 	.then(function (zipPath) {
 		console.log('Downloaded zip:', zipPath);
-		return targz().extract(zipPath, '.');
+		return tar.extract({file: zipPath});
 	})
 	.then(function () {
 		console.log('Libui binaries extracted to:', process.cwd());

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "rc": "^1.1.2",
     "regenerator-runtime": "^0.9.5",
     "request": "^2.72.0",
-    "tar.gz": "^1.0.5"
+    "tar": "^4.4.0"
   },
   "devDependencies": {
     "ava": "^0.15.2",


### PR DESCRIPTION
Gets rid of this warning:
`warning libui-download > tar.gz@1.0.7: ⚠️  WARNING ⚠️ tar.gz module has been deprecated and your application is vulnerable. Please use tar module instead: https://npmjs.com/tar`